### PR TITLE
Working on issue #12 resolving wrong assignment value in pca.

### DIFF
--- a/src/main/java/gr/iti/mklab/visual/dimreduction/PCA.java
+++ b/src/main/java/gr/iti/mklab/visual/dimreduction/PCA.java
@@ -142,8 +142,8 @@ public class PCA {
 		// compute the mean of all the samples
 		for (int i = 0; i < numSamples; i++) {
 			for (int j = 0; j < sampleSize; j++) {
-				double val = A.get(i, j);
-				means.set(j, val);
+				double val = means.get(j);
+				means.set(j, val + A.get(i, j));
 			}
 		}
 		for (int j = 0; j < sampleSize; j++) {


### PR DESCRIPTION
Means vector must be equal to a vector where each component must be the average of the corresponding column components of the matrix A, instead we ended with a vector where each component is equal to the last row component divided by the number of samples. See more in [class](https://github.com/MKLab-ITI/multimedia-indexing/blob/master/src/main/java/gr/iti/mklab/visual/dimreduction/PCA.java) at row 146.
